### PR TITLE
Removed explicit export default

### DIFF
--- a/src/utilities/Formatter.js
+++ b/src/utilities/Formatter.js
@@ -1,7 +1,7 @@
 import pluralize from 'pluralize'
 let changeCase = require('change-case') // How to use import instead?
 
-export default class Formatter {
+export default class {
     static pluralize(word) {
         return pluralize(word)
     }

--- a/test/utilities/Formatter.test.js
+++ b/test/utilities/Formatter.test.js
@@ -1,4 +1,4 @@
-import Formatter from '../../src/utilities/formatter';
+import Formatter from '../../src/utilities/Formatter';
 
 describe("Formatter", () => {
 

--- a/test/utilities/Formatter.test.js
+++ b/test/utilities/Formatter.test.js
@@ -1,16 +1,16 @@
-import F from '../../src/utilities/formatter';
+import Formatter from '../../src/utilities/formatter';
 
 describe("Formatter", () => {
 
     const TEST_WORD = 'anne have three apple';
 
     test('it should snake case properly', () => {
-        expect(F.snakeCase(TEST_WORD))
+        expect(Formatter.snakeCase(TEST_WORD))
             .toBe('anne_have_three_apple');
     });
 
     test('it should camel case properly', () => {
-        expect(F.camelCase(TEST_WORD))
+        expect(Formatter.camelCase(TEST_WORD))
             .toBe('anneHaveThreeApple');
     });
 


### PR DESCRIPTION
Changed
```
export default class Formatter{
```
```
import F from '../../src/utilities/formatter';
```

To
```
export default class {
```
```
import Formatter from '../../src/utilities/Formatter';
```

to fix circle-ci failed builds