### PR TITLE
Listing the core version in the stack tab

### DIFF
--- a/src/components/WorkspaceTabs/Design/StackTab.vue
+++ b/src/components/WorkspaceTabs/Design/StackTab.vue
@@ -1,21 +1,32 @@
 <template>
     <div class="flex flex-col max-w-md mx-auto px-8 bg-white pt-4 text-sm mt-4">
-        <div class="p-8 border mb-4"
+        <div class="px-8 py-2 border bg-blue-500 text-white"
+            
+        >
+            <span class="">
+                You are using pipe-dream/core
+            </span>
+            <span class="ml-2 text-gray-700 bg-gray-200 rounded px-3 py-1 text-black text-xs">v{{core.version()}}</span>
+        </div>        
+        <div class="p-8 border"
             v-for="fileFactory in fileFactories" v-bind:key="fileFactory.title"
         >
             <span>
                 <input type="checkbox" class="mr-2" checked>{{fileFactory.title}}
             </span>
             <span class="ml-2 text-gray-700 bg-gray-200 rounded px-3 py-1 text-black text-xs">v{{fileFactory.version()}}</span>
-        </div>        
+        </div>
     </div>  
 </template>
 
 <script>
+    import core from '../../../PipeDream'
+
     export default {
         data() {
             return {
-                fileFactories: this.$store.state.fileFactories
+                fileFactories: this.$store.state.fileFactories,
+                core
             }
         }
     }


### PR DESCRIPTION
Display version for core (temporary design).
![image](https://user-images.githubusercontent.com/3457668/61885325-f0b71500-aefd-11e9-9417-04c705758a45.png)

### Some off topic
Im testing having `yarn upgrade` in the deploy script of pipedream.ai to keep from having constantly updating core/filefactory versions in `package.json`. After merging this PR I will bump core to `1.0.5` - but pipedream.ai wont have to edit the`^1.0.4`in its composer.json as long as a `yarn upgrade` is triggered. This will work as long as we stay on `1.0.x`.

Current pipedream.ai deploy script:
```
git pull origin master
composer install --no-interaction --prefer-dist --optimize-autoloader
php artisan migrate --force
yarn upgrade
yarn prod
```