### PR TITLE
Add CSS processor plugin and build code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yarn.lock
 .idea
 .coveralls.yml
 coverage
+dist/*

--- a/package.json
+++ b/package.json
@@ -7,8 +7,18 @@
   "author": "Anders Jurisoo <jurisoo@hotmail.com>",
   "license": "MIT",
   "private": false,
-  "devDependencies": {},
+  "devDependencies": {
+    "@babel/core": "7.5.5",
+    "babel-loader": "^8.0.6",
+    "css-loader": "^3.1.0",
+    "cssnano": "^4.1.10",
+    "mini-css-extract-plugin": "^0.8.0",
+    "vue-loader": "^15.7.1",
+    "vue-template-compiler": "^2.6.10",
+    "webpack-cli": "^3.3.6"
+  },
   "scripts": {
+    "build": "webpack --mode production",
     "test": "cross-env NODE_ENV=test jest",
     "coverage": "jest --collectCoverage=true --coverageReporters=text-lcov | ./node_modules/coveralls/bin/coveralls.js"
   },
@@ -25,15 +35,15 @@
     }
   },
   "dependencies": {
-    "coveralls": "^3.0.5",
     "@vue/test-utils": "^1.0.0-beta.29",
-    "babel-core": "^6.26.3",
+    "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",
     "babel-plugin-module-resolver": "^3.2.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "brace": "^0.11.0",
     "change-case": "^3.1.0",
     "collect.js": "^4.6.5",
+    "coveralls": "^3.0.5",
     "cross-env": "^5.1",
     "deepmerge": "^3.2.0",
     "jest": "^24.8.0",
@@ -49,8 +59,8 @@
     "vue": "^2.5.17",
     "vue-highlightjs": "^1.3.3",
     "vue-jest": "^3.0.4",
-    "vue-template-compiler": "^2.6.4",
     "vue-textarea-autosize": "^1.0.4",
-    "vuex": "^3.1.0"
+    "vuex": "^3.1.0",
+    "webpack": "^4.37.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    minimize: true,
+    "plugins": [
+        require('tailwindcss')('tailwind.js'),
+        require('autoprefixer')(),
+        require('cssnano')({ preset: 'default' }),
+    ],
+};

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,14 @@ Pipe Dream core functionality used by other repos.
 ## Installation
 Please refer to the [development guide](https://github.com/pipe-dream/docs/blob/master/README.md#pipe-dreamdocs)
 
+### Building app
+
+To compile JS and CSS, execute:
+
+```
+yarn build
+```
+
 ### Running unit test
 
 To run unit test, execute:

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import PipeDream from './PipeDream'
-import './css/app.css';
 
 export default PipeDream
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import PipeDream from './PipeDream'
-require('./css/app.css');
+import './css/app.css';
 
 export default PipeDream
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import PipeDream from './PipeDream'
+require('./css/app.css');
 
 export default PipeDream
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -1,0 +1,2 @@
+import './css/app.css';
+import './index';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,38 @@
+const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const path = require('path');
+
+module.exports = {
+    entry: './src/index.js',
+    output: {
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'pipe-dream.js',
+        library: 'PipeDreamCore',
+        libraryTarget: 'umd',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    'css-loader',
+                    'postcss-loader',
+                ],
+            }, {
+                test: /\.vue$/,
+                loader: 'vue-loader',
+            }, {
+                test: /\.js$/,
+                loader: 'babel-loader',
+                exclude: /node_modules/,
+            },
+        ]
+    },
+    plugins: [
+        new VueLoaderPlugin(),
+        new MiniCssExtractPlugin({
+            filename: 'pipe-dream.css'
+        }),
+    ]
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 
 module.exports = {
-    entry: './src/index.js',
+    entry: './src/standalone.js',
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'pipe-dream.js',


### PR DESCRIPTION
Run `yarn build` to generate `dist/pipe-dream.css`.

This CSS file can be `import`ed, `require`d, or copy and served as external CSS in HTML file.

The css file result is unoptimized though, lot of tailwind rules that doesn't used (like `.bg-blue-100 etc`). I experiment using cssnano to keep the size down a bit (shave ~397kb to ~292kb). We may reduce this further using [purgecss](https://github.com/FullHuman/purgecss-webpack-plugin).

This also generate `dist/pipe-dream.js` that theoretically could be configured further to be dropped in html directly (as external JS script), but I haven't tested it.